### PR TITLE
Support retrieving all fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ https://support.1password.com/secrets-automation/
 ### usage
 
 Set your hiera.yml to lookup from the onepassword lookup.
-```
+```yaml
 ---
 version: 5
 
@@ -23,10 +23,13 @@ hierarchy:
         - 'puppet-common'
       url: 'http://localhost:8080' ## you can now also use https
       token: 'sometoken'
+      # optional, retrieve everything (as label:value pairs), not just username/password
+      # valid as of version 0.1.4
+      get_all_fields: true 
 ```
 
 next try looking up a key. Note items can have the same title inside onepassword. These are now combined and returned as an array. Does not work yet when multiple vaults are defined.
-```
+```shell
 root@puppet:/# puppet lookup mynote
   note content
 root@puppet:/# puppet lookup dev-db-login
@@ -42,4 +45,29 @@ root@puppet:/# puppet lookup dev-db-login2
 - username: web
   password: web
 ```
+These can be referenced in a puppet manifest using:
+```puppet
+$var = lookup('dev-db-pass')
+$var = lookup('dev-db-login2.password')
+$var = lookup('dev-db-login2.password', undef, undef, 'Default Value')
+```
 
+#### Getting All Fields
+
+if `get_all_fields` is set to `true` in the options, all fields set on a credential are returned from 1password, 
+using label as the key:
+
+```yaml
+puppet lookup 'Test Credential'
+---                                     
+username: root
+password: my_password
+notesPlain: 'This is a password for some server'
+text: test
+text2: test2
+```
+
+These can be referenced in puppet via:
+```puppet
+$var = lookup('Test Credential.text2')
+```


### PR DESCRIPTION
In addition to retrieving username and password, optionally support retrieving all fields stored on a record in 1password so that they can be used in puppet manifests.  No change in behavior unless this option is configured.

When enabled:
* For "Login", adds all fields
* For "Document", no changes
* For others, works like "Login" (returns a Hash) instead of returning just the password.

Minor cleanup for the README