### PR TITLE
Add support for direct 1Password URL lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,17 @@ defaults:  # Used for any hierarchy level that omits these keys.
 hierarchy:
   ....
   - name: "Secret data"
-    lookup_key: onepassword_lookup 
+    lookup_key: onepassword_lookup
     options:
-      vaults: 
+      vaults:
         - 'development'
         - 'puppet-common'
       url: 'http://localhost:8080' ## you can now also use https
       token: 'sometoken'
       # optional, retrieve everything (as label:value pairs), not just username/password
       # valid as of version 0.1.4
-      get_all_fields: true 
+      get_all_fields: true
+      opurls_only: false
 ```
 
 next try looking up a key. Note items can have the same title inside onepassword. These are now combined and returned as an array. Does not work yet when multiple vaults are defined.
@@ -83,7 +84,7 @@ database:
   username: %{lookup('dev-db-login.username')}
   password: %{lookup('dev-db-login.password')}
   host: db.example.com
-  
+
 production:
   db_user: %{lookup('op://production/postgresql/username')}
   db_pass: %{lookup('op://production/postgresql/password')}
@@ -91,14 +92,31 @@ production:
 
 This allows you to reference 1Password credentials directly in your Hiera YAML data files.
 
+#### Only Process op:// URLs (`opurls_only`)
+
+If `opurls_only` is set to `true`, the lookup function will **only** handle keys that start with `op://` and return `not_found` for everything else. This is useful when you want to include `onepassword_lookup` in your hiera hierarchy for all lookups, but restrict its actual activity to direct 1Password URL references — without interfering with other backends (e.g. YAML data).
+
+```yaml
+  - name: "Secret data"
+    lookup_key: onepassword_lookup
+    options:
+      vaults:
+        - 'production'
+      url: 'http://localhost:8080'
+      token: 'sometoken'
+      opurls_only: true   # only resolve op://vault/item/field keys
+```
+
+With this setting, a lookup like `puppet lookup 'my-yaml-key'` is passed through to the next hierarchy level, while `puppet lookup 'op://production/postgresql/password'` is resolved by this backend.
+
 #### Getting All Fields
 
-if `get_all_fields` is set to `true` in the options, all fields set on a credential are returned from 1password, 
+if `get_all_fields` is set to `true` in the options, all fields set on a credential are returned from 1password,
 using label as the key:
 
 ```yaml
 puppet lookup 'Test Credential'
----                                     
+---
 username: root
 password: my_password
 notesPlain: 'This is a password for some server'

--- a/README.md
+++ b/README.md
@@ -45,12 +45,51 @@ root@puppet:/# puppet lookup dev-db-login2
 - username: web
   password: web
 ```
+
+#### Direct 1Password URL Lookups
+
+You can also use direct 1Password URLs for lookups in the format `op://vault/item/field`. This skips vault iteration and directly retrieves the specified field:
+
+```shell
+root@puppet:/# puppet lookup 'op://production/postgresql/password'
+--- geheim123
+root@puppet:/# puppet lookup 'op://production/postgresql/username'
+--- admin
+```
+
+**Advantages:**
+- Better performance (no vault iteration)
+- More explicit and clear intent
+- Access to any field, not just password
+
+These can be referenced in a puppet manifest using:
+```puppet
+$var = lookup('op://production/postgresql/password')
+$var = lookup('op://production/postgresql/username')
+```
+
+#### Standard Hiera Dot-Notation
+
 These can be referenced in a puppet manifest using:
 ```puppet
 $var = lookup('dev-db-pass')
 $var = lookup('dev-db-login2.password')
 $var = lookup('dev-db-login2.password', undef, undef, 'Default Value')
 ```
+
+You can also use the Hiera interpolation syntax `%{lookup(...)}` in YAML files:
+```yaml
+database:
+  username: %{lookup('dev-db-login.username')}
+  password: %{lookup('dev-db-login.password')}
+  host: db.example.com
+  
+production:
+  db_user: %{lookup('op://production/postgresql/username')}
+  db_pass: %{lookup('op://production/postgresql/password')}
+```
+
+This allows you to reference 1Password credentials directly in your Hiera YAML data files.
 
 #### Getting All Fields
 
@@ -70,4 +109,11 @@ text2: test2
 These can be referenced in puppet via:
 ```puppet
 $var = lookup('Test Credential.text2')
+```
+
+Or in YAML files:
+```yaml
+my_config:
+  username: %{lookup('Test Credential.username')}
+  custom_field: %{lookup('Test Credential.text2')}
 ```

--- a/lib/puppet/functions/onepassword_lookup.rb
+++ b/lib/puppet/functions/onepassword_lookup.rb
@@ -12,6 +12,15 @@ Puppet::Functions.create_function(:onepassword_lookup) do
 
   def onepassword_lookup(key, options, context)
     return context.cached_value(key) if context.cache_has_key(key)
+    # if opurls_only is set to true, then we will only look for keys that start with op://, and if the key does not start with op://, we will return not_found.
+    # This allows for using this lookup_key function in hiera.yaml for all lookups, but only actually using it for keys that start with op://, and not having it interfere with other lookups.
+    if options.include?('opurls_only') && options['opurls_only'] == true
+      if not key.start_with?("op://")
+        context.not_found
+        return
+      end
+    end
+
     unless options.include?('vaults') || options.include?('vault')
       #TRANSLATORS 'onepassword_lookup':, 'path', 'paths' 'glob', 'globs', 'mapped_paths', and lookup_key should not be translated
       raise ArgumentError,

--- a/lib/puppet/functions/onepassword_lookup.rb
+++ b/lib/puppet/functions/onepassword_lookup.rb
@@ -11,7 +11,6 @@ Puppet::Functions.create_function(:onepassword_lookup) do
   end
 
   def onepassword_lookup(key, options, context)
-
     return context.cached_value(key) if context.cache_has_key(key)
     unless options.include?('vaults') || options.include?('vault')
       #TRANSLATORS 'onepassword_lookup':, 'path', 'paths' 'glob', 'globs', 'mapped_paths', and lookup_key should not be translated
@@ -64,7 +63,6 @@ Puppet::Functions.create_function(:onepassword_lookup) do
     if var.nil?
       context.not_found
     else
-      # Puppet.notice(get_password_from_item(options['url'], options['token'], options['get_all_fields'] || false, var))  # Wird immer angezeigt
       if field_to_return        # if the key was in the format op://vault/item/field, then we need to return only the specified field from the item
           context.cache(key,get_password_from_item(options['url'], options['token'], options['get_all_fields'] || false, var)[ field_to_return ])
       else

--- a/lib/puppet/functions/onepassword_lookup.rb
+++ b/lib/puppet/functions/onepassword_lookup.rb
@@ -11,6 +11,7 @@ Puppet::Functions.create_function(:onepassword_lookup) do
   end
 
   def onepassword_lookup(key, options, context)
+
     return context.cached_value(key) if context.cache_has_key(key)
     unless options.include?('vaults') || options.include?('vault')
       #TRANSLATORS 'onepassword_lookup':, 'path', 'paths' 'glob', 'globs', 'mapped_paths', and lookup_key should not be translated
@@ -40,6 +41,20 @@ Puppet::Functions.create_function(:onepassword_lookup) do
         vaults_to_search.append(v)
       end
     end
+    # if key=~op://vault/item/field, then we can directly query for the item.  Otherwise, we need to loop through vaults and items to find the right one.
+    if key.start_with?("op://")
+      parts = key[5..-1].split('/')
+      if parts.length != 3
+        raise ArgumentError,
+          _("'onepassword_lookup': If key starts with 'op://', it must be in the format 'op://vault/item/field'")
+      end
+      vaults_to_search = [parts[0]]
+      key = parts[1] # we will search for an item with the name of parts[1], and then return the field with the name of parts[2] from that item.  This allows for direct lookup of items without having to loop through all items in all vaults.  It also allows for lookup of fields other than password, such as username or any custom field.
+      field_to_return = parts[2]
+    else
+      field_to_return = nil
+    end
+
     raw_data = context.cached_value(nil)
     var = nil
     vaults_to_search.each do |vault|
@@ -49,21 +64,25 @@ Puppet::Functions.create_function(:onepassword_lookup) do
     if var.nil?
       context.not_found
     else
-      context.cache(key, get_password_from_item(options['url'], options['token'], options['get_all_fields'] || false, var))
+      # Puppet.notice(get_password_from_item(options['url'], options['token'], options['get_all_fields'] || false, var))  # Wird immer angezeigt
+      if field_to_return        # if the key was in the format op://vault/item/field, then we need to return only the specified field from the item
+          context.cache(key,get_password_from_item(options['url'], options['token'], options['get_all_fields'] || false, var)[ field_to_return ])
+      else
+        context.cache(key, get_password_from_item(options['url'], options['token'], options['get_all_fields'] || false, var))
+      end
     end
-    
+
     # if raw_data.nil?
     #   raw_data = load_data_hash(options, context)
     #   context.cache(nil, raw_data)
     # end
     # context.not_found unless raw_data.include?(key)
     # context.cache(key, vaults_to_search)
-  
   end
 
 
 
-  
+
   def get_vaults(base_url, token, debug)
     url = URI(base_url + "/v1/vaults")
     http = Net::HTTP.new(url.host, url.port)
@@ -75,7 +94,7 @@ Puppet::Functions.create_function(:onepassword_lookup) do
     request["authorization"] = 'Authorization: Bearer ' + token
     request["content-type"] = 'application/json'
     request["cache-control"] = 'no-cache'
-    
+
     response = http.request(request)
     arr = []
     if response.kind_of? Net::HTTPSuccess
@@ -153,7 +172,7 @@ Puppet::Functions.create_function(:onepassword_lookup) do
     vault = get_vault_by_name(base_url, token, vault_name)
     vars = []
     var = nil
-    unless vault.nil? 
+    unless vault.nil?
         items = get_vault_items(base_url,token, vault['id'], false)
         items.each do |item|
             if item['name'] == item_name
@@ -172,7 +191,7 @@ Puppet::Functions.create_function(:onepassword_lookup) do
     end
   end
 
-  
+
   def get_file_content(base_url, token, vault_id, item_id, file_id)
     url = URI(base_url + "/v1/vaults/" + vault_id + "/items/" + item_id + "/files/" + file_id + "/content")
     http = Net::HTTP.new(url.host, url.port)
@@ -219,7 +238,7 @@ Puppet::Functions.create_function(:onepassword_lookup) do
               end
             end
           end
-              
+
       end
       content
   end


### PR DESCRIPTION
## Add support for direct 1Password URL lookups

### Description
This PR adds support for direct 1Password item and field lookups using the `op://vault/item/field` URL format, eliminating the need to loop through all vaults and items when the exact location is known.

### Changes
- **New feature**: Support for `op://` URLs in lookup keys
  - Format: `op://vault_name/item_name/field_name`
  - Directly queries the specified vault and item without iteration
  - Allows access to any field (not just password)
  
- **Implementation details**:
  - Parses `op://` URLs and extracts vault, item, and field names
  - Falls back to standard Hiera dot-notation for non-URL lookups
  - Returns only the specified field when using the URL format
  - Validates URL format and raises an error for invalid formats

### Example Usage
```bash
# Direct field lookup
puppet lookup 'op://production/postgresql/password'
puppet lookup 'op://production/postgresql/username'

# Standard Hiera dot-notation (unchanged)
puppet lookup postgresql.password
```

### Benefits
- ✅ Better performance for direct lookups (no vault iteration)
- ✅ More explicit and clear intent in manifests
- ✅ Supports accessing any custom field, not just password
- ✅ Backwards compatible - existing Hiera dot-notation still works